### PR TITLE
Persist user on login (protected routes)

### DIFF
--- a/backend/src/user/types.ts
+++ b/backend/src/user/types.ts
@@ -23,6 +23,8 @@ type ITokenType = 'ACCESS' | 'REFRESH';
 interface IUser {
   id: number;
   username: string;
+  firstName: string;
+  lastName: string;
   password: string;
   refreshToken: string;
   generateTokens(): Promise<IGeneratedTokens>;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -22,7 +22,8 @@ const signIn = async ({ body: { username, password } }: ISignInRequest, res: Res
   const tokens = await user.generateTokens();
   setAuthCookies(tokens, res);
 
-  return res.status(OK).send();
+  const { id, firstName, lastName } = user;
+  return res.status(OK).json({ id, username, firstName, lastName });
 };
 
 const register = async ({ body }: IRegisterRequest, res: Response, next: NextFunction) => {
@@ -32,7 +33,8 @@ const register = async ({ body }: IRegisterRequest, res: Response, next: NextFun
     const tokens = await user.generateTokens();
     setAuthCookies(tokens, res);
 
-    return res.status(CREATED).send();
+    const { id, username, firstName, lastName } = user;
+    return res.status(CREATED).json({ id, username, firstName, lastName });
   } catch (err) {
     if (err instanceof UniqueConstraintError) {
       return next(new HttpError(CONFLICT, errorMessages.REGISTER_ERROR));

--- a/backend/src/user/user.model.ts
+++ b/backend/src/user/user.model.ts
@@ -8,6 +8,8 @@ import { Model } from 'sequelize';
 class User extends Model implements IUser {
   id!: number;
   username!: string;
+  firstName!: string;
+  lastName!: string;
   password!: string;
   refreshToken!: string;
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,10 @@
     "lint": "eslint ./"
   },
   "dependencies": {
+    "@vueuse/core": "^9.0.0",
     "axios": "^0.27.2",
     "normalize.css": "^8.0.1",
+    "pinia": "^2.0.17",
     "vue": "^3.2.25",
     "vue-router": "^4.1.2"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@babel/eslint-plugin': ^7.17.7
   '@extensionengine/eslint-config': ^3.0.1
   '@vitejs/plugin-vue': ^3.0.1
+  '@vueuse/core': ^9.0.0
   axios: ^0.27.2
   eslint: ^8.19.0
   eslint-config-prettier: ^8.5.0
@@ -19,14 +20,17 @@ specifiers:
   eslint-plugin-require-sort: ^1.2.2
   eslint-plugin-vue: ^9.2.0
   normalize.css: ^8.0.1
+  pinia: ^2.0.17
   prettier: ^2.7.1
   vite: ^3.0.2
   vue: ^3.2.25
   vue-router: ^4.1.2
 
 dependencies:
+  '@vueuse/core': 9.0.0_vue@3.2.37
   axios: 0.27.2
   normalize.css: 8.0.1
+  pinia: 2.0.17_vue@3.2.37
   vue: 3.2.37
   vue-router: 4.1.2_vue@3.2.37
 
@@ -370,6 +374,10 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
+  /@types/web-bluetooth/0.0.15:
+    resolution: {integrity: sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==}
+    dev: false
+
   /@vitejs/plugin-vue/3.0.1_vite@3.0.2+vue@3.2.37:
     resolution: {integrity: sha512-Ll9JgxG7ONIz/XZv3dssfoMUDu9qAnlJ+km+pBA0teYSXzwPCIzS/e1bmwNYl5dcQGs677D21amgfYAnzMl17A==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -457,6 +465,31 @@ packages:
 
   /@vue/shared/3.2.37:
     resolution: {integrity: sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==}
+
+  /@vueuse/core/9.0.0_vue@3.2.37:
+    resolution: {integrity: sha512-hMMc2ajuVknkL7Z39JdP9gFFND2OgnDTSS5mmuinWGAE1Vxy1AwDvTHm3+juyk+GzJjYRAktnBIPy7Fq53iOnw==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.15
+      '@vueuse/metadata': 9.0.0
+      '@vueuse/shared': 9.0.0_vue@3.2.37
+      vue-demi: 0.13.5_vue@3.2.37
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
+
+  /@vueuse/metadata/9.0.0:
+    resolution: {integrity: sha512-79YVIsAP1bbWm5GdQuG7jDVF/9uuExzhkO0Sd4/TLuSfzH2uZOrHvGwy+ZNJHjbyRn3uf56rKINWLJdBuTLSqQ==}
+    dev: false
+
+  /@vueuse/shared/9.0.0_vue@3.2.37:
+    resolution: {integrity: sha512-WRCyr/wIz5e/2gR/+qFucbCUcGMyJKkQZAzlECl3e71ebQQ9X/w3aBWT9FbnogJX+DNZ/t3Pj+TqPbC7TH1Yog==}
+    dependencies:
+      vue-demi: 0.13.5_vue@3.2.37
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
 
   /acorn-jsx/5.3.2_acorn@8.7.1:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1880,6 +1913,23 @@ packages:
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
+  /pinia/2.0.17_vue@3.2.37:
+    resolution: {integrity: sha512-AtwLwEWQgIjofjgeFT+nxbnK5lT2QwQjaHNEDqpsi2AiCwf/NY78uWTeHUyEhiiJy8+sBmw0ujgQMoQbWiZDfA==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.2.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/devtools-api': 6.2.1
+      vue: 3.2.37
+      vue-demi: 0.13.5_vue@3.2.37
+    dev: false
+
   /postcss-selector-parser/6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -2151,6 +2201,21 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  /vue-demi/0.13.5_vue@3.2.37:
+    resolution: {integrity: sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.2.37
+    dev: false
 
   /vue-eslint-parser/9.0.3_eslint@8.19.0:
     resolution: {integrity: sha512-yL+ZDb+9T0ELG4VIFo/2anAOz8SvBdlqEnQnvJ3M7Scq56DvtjY0VY88bByRZB0D4J0u8olBcfrXTVONXsh4og==}

--- a/frontend/src/components/auth/UserRegister.vue
+++ b/frontend/src/components/auth/UserRegister.vue
@@ -12,6 +12,7 @@ import { setErrorToLastForm, validateAuthForm } from '@/utils/validation';
 import { auth as authApi } from '@/api';
 import { reactive } from 'vue';
 import { registerFormLabels } from './constants';
+import { useAuthStore } from '@/store/authStore';
 import UserForm from './UserForm.vue';
 import { useRouter } from 'vue-router';
 
@@ -19,6 +20,10 @@ export default {
   name: 'user-register',
   setup() {
     const router = useRouter();
+    const userStore = useAuthStore();
+
+    console.log(userStore.getUser);
+
     const formInputs = reactive(registerFormLabels.formInputs);
 
     const submit = async () => {
@@ -30,7 +35,8 @@ export default {
       const password = formInputs.password.value;
 
       try {
-        await authApi.register({ username, firstName, lastName, password });
+        const user = await authApi.register({ username, firstName, lastName, password });
+        userStore.setUser(user);
         router.push({ name: 'Tags' });
       } catch (err) {
         setErrorToLastForm(formInputs, err.response.data.message);

--- a/frontend/src/components/auth/UserRegister.vue
+++ b/frontend/src/components/auth/UserRegister.vue
@@ -22,8 +22,6 @@ export default {
     const router = useRouter();
     const userStore = useAuthStore();
 
-    console.log(userStore.getUser);
-
     const formInputs = reactive(registerFormLabels.formInputs);
 
     const submit = async () => {

--- a/frontend/src/components/auth/UserSignIn.vue
+++ b/frontend/src/components/auth/UserSignIn.vue
@@ -12,7 +12,7 @@ import { setErrorToLastForm, validateAuthForm } from '@/utils/validation';
 import { auth as authApi } from '@/api';
 import { reactive } from 'vue';
 import { signInFormLabels } from './constants';
-import { useAuthStore } from '../../store/authStore';
+import { useAuthStore } from '@/store/authStore';
 import UserForm from './UserForm.vue';
 import { useRouter } from 'vue-router';
 

--- a/frontend/src/components/auth/UserSignIn.vue
+++ b/frontend/src/components/auth/UserSignIn.vue
@@ -12,6 +12,7 @@ import { setErrorToLastForm, validateAuthForm } from '@/utils/validation';
 import { auth as authApi } from '@/api';
 import { reactive } from 'vue';
 import { signInFormLabels } from './constants';
+import { useAuthStore } from '../../store/authStore';
 import UserForm from './UserForm.vue';
 import { useRouter } from 'vue-router';
 
@@ -19,6 +20,8 @@ export default {
   name: 'user-sign-in',
   setup() {
     const router = useRouter();
+    const authStore = useAuthStore();
+
     const formInputs = reactive(signInFormLabels.formInputs);
 
     const submit = async () => {
@@ -28,7 +31,8 @@ export default {
       const password = formInputs.password.value;
 
       try {
-        await authApi.signIn({ username, password });
+        const user = await authApi.signIn({ username, password });
+        authStore.setUser(user);
         router.push({ name: 'Home' });
       } catch (err) {
         setErrorToLastForm(formInputs, err.response.data.message);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,11 +3,13 @@ import ChiButton from './components/common/ChiButton.vue';
 import ChiField from './components/common/ChiField.vue';
 
 import { createApp } from 'vue';
+import { createPinia } from 'pinia';
 import router from './router';
 import vAutofocus from './directives/vAutofocus';
 
 createApp(App)
   .use(router)
+  .use(createPinia())
   .component('ChiButton', ChiButton)
   .component('ChiField', ChiField)
   .directive('autofocus', vAutofocus)

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -28,7 +28,7 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from) => {
-  const isLoggedIn = !!useAuthStore().getUser.id;
+  const isLoggedIn = useAuthStore().isLoggedIn;
   const isAuthRoute = to.name === 'Auth';
 
   if (!isLoggedIn && !isAuthRoute) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -28,13 +28,14 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from) => {
-  const user = useAuthStore().getUser;
+  const isLoggedIn = !!useAuthStore().getUser.id;
+  const isAuthRoute = to.name === 'Auth';
 
-  if (!user.id && to.name !== 'Auth') {
+  if (!isLoggedIn && !isAuthRoute) {
     return { name: 'Auth' };
   }
 
-  if (!!user.id && to.name === 'Auth') {
+  if (isLoggedIn && isAuthRoute) {
     return { name: 'Home' };
   }
 });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -27,7 +27,7 @@ const router = createRouter({
   routes,
 });
 
-router.beforeEach(async (to, from) => {
+router.beforeEach((to, from) => {
   const user = useAuthStore().getUser;
 
   if (!user.id && to.name !== 'Auth') {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -28,8 +28,14 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from) => {
-  if (!useAuthStore().getUser.id && to.name !== 'Auth') {
+  const user = useAuthStore().getUser;
+
+  if (!user.id && to.name !== 'Auth') {
     return { name: 'Auth' };
+  }
+
+  if (!!user.id && to.name === 'Auth') {
+    return { name: 'Home' };
   }
 });
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from '@/components/HomeTemp.vue';
 import TagSelect from '@/components/tags/TagSelect.vue';
+import { useAuthStore } from '@/store/authStore';
 import UserAuth from '@/components/auth/UserAuth.vue';
 
 const routes = [
@@ -11,7 +12,7 @@ const routes = [
   },
   {
     path: '/auth',
-    name: 'UserAuth',
+    name: 'Auth',
     component: UserAuth,
   },
   {
@@ -24,6 +25,12 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+});
+
+router.beforeEach(async (to, from) => {
+  if (!useAuthStore().getUser.id && to.name !== 'Auth') {
+    return { name: 'Auth' };
+  }
 });
 
 export default router;

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -1,19 +1,16 @@
+import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-export const useAuthStore = defineStore({
-  state: () => ({
-    user: {},
-  }),
+export const useAuthStore = defineStore('user', () => {
+  const user = ref({});
 
-  getters: {
-    getUser() {
-      return this.user;
-    },
-  },
+  const getUser = computed(() => {
+    return user.value;
+  });
 
-  actions: {
-    setUser(user) {
-      this.user = user;
-    },
-  },
+  const setUser = userToSet => {
+    user.value = userToSet;
+  };
+
+  return { user, getUser, setUser };
 });

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -1,8 +1,9 @@
 import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
+import { useStorage } from '@vueuse/core';
 
-export const useAuthStore = defineStore('user', () => {
-  const user = ref({});
+export const useAuthStore = defineStore('auth', () => {
+  const user = ref(useStorage('user', {}));
 
   const getUser = computed(() => {
     return user.value;

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia';
+
+export const useAuthStore = defineStore({
+  state: () => ({
+    user: {},
+  }),
+
+  getters: {
+    getUser() {
+      return this.user;
+    },
+  },
+
+  actions: {
+    setUser(user) {
+      this.user = user;
+    },
+  },
+});

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -9,9 +9,13 @@ export const useAuthStore = defineStore('auth', () => {
     return user.value;
   });
 
+  const isLoggedIn = computed(() => {
+    return !!user.value.id;
+  });
+
   const setUser = userToSet => {
     user.value = userToSet;
   };
 
-  return { user, getUser, setUser };
+  return { user, getUser, isLoggedIn, setUser };
 });


### PR DESCRIPTION
This PR adds the user to the frontend persistent storage (`localstorage`) and pinia store. By modifying `signIn` and `register` on the backend to return the authenticated/created user the frontend is able to store the user in `localstorage` and access, set... it through pinia store. 

The pinia store uses `Composition API` syntax and is connected to `localstorage` with `@vueuse/core` `useStorage` method.

How it works and what to test
1.  a user that is not signed in cannot access any route except `/auth`
2. a signed in user cannot access `/auth` route
3. the user information should be saved in `localstorage` as an object (empty if not signed in)

Closes #32 