### PR TITLE
Protect endpoints and error interceptor

### DIFF
--- a/backend/src/tag/index.ts
+++ b/backend/src/tag/index.ts
@@ -1,9 +1,11 @@
+import authenticate from 'shared/auth/authenticate';
 import { getAll } from './tag.controller';
+import refresh from 'shared/auth/refresh';
 import { Router } from 'express';
 
 const router = Router();
 const path = '/tags';
 
-router.get('/', getAll);
+router.get('/', authenticate, refresh, getAll);
 
 export default { router, path };

--- a/backend/src/user/index.ts
+++ b/backend/src/user/index.ts
@@ -1,9 +1,9 @@
-import { getAll, register, signIn, signOut } from './user.controller';
+import { register, signIn, signOut } from './user.controller';
 import { Router } from 'express';
 
 const router = Router();
 const path = '/users';
 
-router.get('/', getAll).post('/sign-in', signIn).post('/register', register).post('/sign-out', signOut);
+router.post('/sign-in', signIn).post('/register', register).post('/sign-out', signOut);
 
 export default { router, path };

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -7,11 +7,6 @@ import HttpError from 'shared/error/httpError';
 import { UniqueConstraintError } from 'sequelize';
 import { User } from 'shared/database';
 
-const getAll = async (req: Request, res: Response) => {
-  const data = await User.findAll();
-  return res.json(data);
-};
-
 const signIn = async ({ body: { username, password } }: ISignInRequest, res: Response, next: NextFunction) => {
   const user = await User.unscoped().findOne({ where: { username } });
   if (!user) return next(new HttpError(UNAUTHORIZED, errorMessages.SIGN_IN_ERROR));
@@ -48,4 +43,4 @@ const signOut = (req: Request, res: Response) => {
   res.status(OK).send();
 };
 
-export { getAll, signIn, register, signOut };
+export { signIn, register, signOut };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@vueuse/core": "^9.0.0",
     "axios": "^0.27.2",
+    "http-status-codes": "^2.2.0",
     "normalize.css": "^8.0.1",
     "pinia": "^2.0.17",
     "vue": "^3.2.25",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -19,6 +19,7 @@ specifiers:
   eslint-plugin-promise: ^6.0.0
   eslint-plugin-require-sort: ^1.2.2
   eslint-plugin-vue: ^9.2.0
+  http-status-codes: ^2.2.0
   normalize.css: ^8.0.1
   pinia: ^2.0.17
   prettier: ^2.7.1
@@ -29,6 +30,7 @@ specifiers:
 dependencies:
   '@vueuse/core': 9.0.0_vue@3.2.37
   axios: 0.27.2
+  http-status-codes: 2.2.0
   normalize.css: 8.0.1
   pinia: 2.0.17_vue@3.2.37
   vue: 3.2.37
@@ -1555,6 +1557,10 @@ packages:
     dependencies:
       function-bind: 1.1.1
     dev: true
+
+  /http-status-codes/2.2.0:
+    resolution: {integrity: sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==}
+    dev: false
 
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}

--- a/frontend/src/api/request.js
+++ b/frontend/src/api/request.js
@@ -1,4 +1,8 @@
 import axios from 'axios';
+import { StatusCodes } from 'http-status-codes';
+import { useAuthStore } from '@/store/authStore';
+
+const { FORBIDDEN } = StatusCodes;
 
 const config = {
   baseURL: '/api',
@@ -6,5 +10,19 @@ const config = {
 };
 
 const client = axios.create(config);
+
+const isAuthError = err => [FORBIDDEN].includes(err.response.status);
+
+client.interceptors.response.use(
+  res => res,
+  err => {
+    if (isAuthError(err)) {
+      useAuthStore().removeUser();
+      return window.location.reload();
+    }
+
+    throw err;
+  },
+);
 
 export default client;

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -19,12 +19,15 @@ export const useAuthStore = defineStore('auth', () => {
     user.value = userToSet;
   };
 
-
-  const signOut = async router => {
-    await authApi.signOut();
-    router.push({ name: 'Auth' });
+  const removeUser = () => {
     user.value = {};
   };
 
-  return { user, getUser, isLoggedIn, setUser, signOut };
+  const signOut = async router => {
+    await authApi.signOut();
+    removeUser();
+    router.push({ name: 'Auth' });
+  };
+
+  return { user, getUser, isLoggedIn, setUser, removeUser, signOut };
 });


### PR DESCRIPTION
Protect current routes - `tags` with `authenticate` and `refresh` middleware and add axios interceptor to remove the user if the response is `FORBIDDEN`

To test, set the expiry of refresh token to about `30s`. Register/sign in on `/auth` and go to `tags` after. You should see the tags displayed correctly. Wait for the expiry time you set to pass and then refresh the page. You should be redirected to `auth` and your user should be removed from `localstoreage`

Closes #36